### PR TITLE
CANDI-1033: Release version 1.1.0-jora

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ install_manifest.txt
 *.bundle
 *.so
 *.dll
+*.gem

--- a/cld2.gemspec
+++ b/cld2.gemspec
@@ -19,4 +19,5 @@ Gem::Specification.new do |gem|
   gem.add_dependency "ffi", "~> 1.9.3"
 
   gem.add_development_dependency "rspec", "~> 2.14.1"
+  gem.license = 'Nonstandard'
 end

--- a/ext/cld/extconf.rb
+++ b/ext/cld/extconf.rb
@@ -27,6 +27,9 @@ $objs = ["internal/cldutil.o",
   "internal/cld_generated_score_quad_octa_0122_2.o",
   "thunk.o"]
 
+# Prevents issues compiling with newer GCC versions
+$defs.push("-std=c++98")
+
 if have_library('stdc++')
   create_makefile('libcld2')
 end

--- a/lib/cld/version.rb
+++ b/lib/cld/version.rb
@@ -1,3 +1,3 @@
 module CLD
-  VERSION = "1.0.3"
+  VERSION = "1.1.0.jora".freeze
 end


### PR DESCRIPTION
This releases the version we use as `1.1.0-jora`.

## Why?

Today, we use a special branch name:

```ruby
gem 'cld2', jora: 'cld2', branch: 'fix-gcc-error'
```

But it'd be better if we can just use a version:

```diff
-gem 'cld2', jora: 'cld2', branch: 'fix-gcc-error'
+gem 'cld2', jora: 'cld2', tag: 'v1.1.0.jora'
```

I'm adding the `.jora` prerelease suffix so that it doesn't clash with upstream cld2 versions.

## References

https://jobseeker.atlassian.net/browse/CANDI-1033

## TODO

After merging this, I need to create a git tag and a GitHub release